### PR TITLE
IaC Import Auto Load & Fixed Dark Mode Issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lc-detectionforge",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lc-detectionforge",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lc-detectionforge",
   "description": "A comprehensive detection engineering environment for crafting, validating, and testing LimaCharlie detection rules",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -573,6 +573,11 @@ body.config {
   letter-spacing: 0.5px;
 }
 
+/* Dark mode specific styling for current badge */
+[data-theme='dark'] .changelog .current-badge {
+  color: var(--bg-primary);
+}
+
 .changelog .changes {
   display: flex;
   flex-direction: column;

--- a/src/components/Rules.vue
+++ b/src/components/Rules.vue
@@ -1423,6 +1423,17 @@ hives:
                   ></textarea>
                 </div>
 
+                <div class="import-options">
+                  <label class="checkbox-wrapper">
+                    <input
+                      type="checkbox"
+                      v-model="autoOpenTopRule"
+                      :disabled="isImportingIaC"
+                    />
+                    <span class="checkbox-label">Automatically open first imported rule</span>
+                  </label>
+                </div>
+
                 <div class="import-actions">
                   <button
                     type="submit"
@@ -1635,6 +1646,9 @@ const iacImportResult = ref<{
   message: string
   importedRules: Array<{ name: string; success: boolean; error?: string }>
 } | null>(null)
+
+// Auto-open top rule checkbox state (persistent)
+const autoOpenTopRule = ref(localStorage.getItem('detectionforge_auto_open_top_rule') === 'true')
 
 // Event Schemas functionality
 const selectedEventType = ref('')
@@ -4874,6 +4888,29 @@ async function importFromIaC() {
         'success',
         `Imported ${successCount} detection rule${successCount !== 1 ? 's' : ''} from IaC`,
       )
+
+      // Auto-open the first successfully imported rule if checkbox is checked
+      if (autoOpenTopRule.value) {
+        const firstSuccessfulImport = importedRules.find(rule => rule.success)
+        if (firstSuccessfulImport) {
+          // Find the rule ID by name from the saved rules
+          const savedRulesList = JSON.parse(localStorage.getItem(DETECTION_RULES_KEY) || '[]')
+          const ruleToOpen = savedRulesList.find((r: DetectionRule) => r.name === firstSuccessfulImport.name)
+          if (ruleToOpen) {
+                         // Use nextTick to ensure the DOM is updated before loading the rule
+             nextTick(() => {
+               loadRule(ruleToOpen.id)
+               // Add notification that rule was loaded to editor
+               appStore.addNotification(
+                 'info',
+                 `Loaded "${firstSuccessfulImport.name}" to editor`
+               )
+               // Close the import modal
+               showImportIaCModal.value = false
+             })
+          }
+        }
+      }
     } else {
       appStore.addNotification('error', 'Failed to import any rules from IaC content')
     }
@@ -4893,5 +4930,10 @@ async function importFromIaC() {
 // Watch for prefix changes to reset selection
 watch(selectedPrefix, () => {
   onPrefixChange()
+})
+
+// Watch for auto-open checkbox changes to persist state
+watch(autoOpenTopRule, (newValue) => {
+  localStorage.setItem('detectionforge_auto_open_top_rule', newValue.toString())
 })
 </script>

--- a/src/components/Rules.vue
+++ b/src/components/Rules.vue
@@ -1425,11 +1425,7 @@ hives:
 
                 <div class="import-options">
                   <label class="checkbox-wrapper">
-                    <input
-                      type="checkbox"
-                      v-model="autoOpenTopRule"
-                      :disabled="isImportingIaC"
-                    />
+                    <input v-model="autoOpenTopRule" type="checkbox" :disabled="isImportingIaC" />
                     <span class="checkbox-label">Automatically open first imported rule</span>
                   </label>
                 </div>
@@ -4891,23 +4887,22 @@ async function importFromIaC() {
 
       // Auto-open the first successfully imported rule if checkbox is checked
       if (autoOpenTopRule.value) {
-        const firstSuccessfulImport = importedRules.find(rule => rule.success)
+        const firstSuccessfulImport = importedRules.find((rule) => rule.success)
         if (firstSuccessfulImport) {
           // Find the rule ID by name from the saved rules
           const savedRulesList = JSON.parse(localStorage.getItem(DETECTION_RULES_KEY) || '[]')
-          const ruleToOpen = savedRulesList.find((r: DetectionRule) => r.name === firstSuccessfulImport.name)
+          const ruleToOpen = savedRulesList.find(
+            (r: DetectionRule) => r.name === firstSuccessfulImport.name,
+          )
           if (ruleToOpen) {
-                         // Use nextTick to ensure the DOM is updated before loading the rule
-             nextTick(() => {
-               loadRule(ruleToOpen.id)
-               // Add notification that rule was loaded to editor
-               appStore.addNotification(
-                 'info',
-                 `Loaded "${firstSuccessfulImport.name}" to editor`
-               )
-               // Close the import modal
-               showImportIaCModal.value = false
-             })
+            // Use nextTick to ensure the DOM is updated before loading the rule
+            nextTick(() => {
+              loadRule(ruleToOpen.id)
+              // Add notification that rule was loaded to editor
+              appStore.addNotification('info', `Loaded "${firstSuccessfulImport.name}" to editor`)
+              // Close the import modal
+              showImportIaCModal.value = false
+            })
           }
         }
       }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -36,6 +36,18 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '1.3.0',
+    date: '2025-06-27',
+    changes: {
+      added: [
+        'Automatically Load IaC Imports - Checkbox in the IaC import screen that allows for automatic loading of first (top-most) rule',
+      ],
+      fixed: [
+        'In dark mode the "Current" label text was not visible',
+      ],
+    },
+  },
+  {
     version: '1.2.0',
     date: '2025-06-26',
     changes: {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -42,9 +42,7 @@ export const CHANGELOG: ChangelogEntry[] = [
       added: [
         'Automatically Load IaC Imports - Checkbox in the IaC import screen that allows for automatic loading of first (top-most) rule',
       ],
-      fixed: [
-        'In dark mode the "Current" label text was not visible',
-      ],
+      fixed: ['In dark mode the "Current" label text was not visible'],
     },
   },
   {


### PR DESCRIPTION
Added:
- Inside of the IaC rule importer, created a persistent state checkbox labeled "Automatically open first imported rule". When one or more rules are imported via the IaC importer, this checkbox when checked automatically opens the first (top-most) in the editor.

Fixed:
- Issue where changelog 'current' text label was not visible in dark mode