### PR TITLE
Release v1.4.1: Critical backtest stateful processing fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lc-detectionforge",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lc-detectionforge",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lc-detectionforge",
   "description": "A comprehensive detection engineering environment for crafting, validating, and testing LimaCharlie detection rules",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/src/components/Rules.vue
+++ b/src/components/Rules.vue
@@ -4138,7 +4138,7 @@ async function runBacktest() {
             backtestConfig.evalLimit,
             backtestAbortController || undefined,
             30 * 60 * 1000, // 30 minute timeout
-            !backtestConfig.isStateful,
+            backtestConfig.isStateful,
             false, // isDryRun
             '', // Initial cursor (empty string for new queries)
           )
@@ -4301,7 +4301,7 @@ async function runBacktest() {
             backtestConfig.evalLimit,
             backtestAbortController || undefined,
             30 * 60 * 1000, // 30 minute timeout
-            !backtestConfig.isStateful,
+            backtestConfig.isStateful,
             false, // isDryRun
             '', // Initial cursor (empty string for new queries)
           )
@@ -4559,7 +4559,7 @@ async function loadMoreResultsForOrg(orgIndex: number) {
       0,
       undefined, // No abort controller for additional fetches
       10 * 60 * 1000, // 10 minute timeout
-      !backtestConfig.isStateful,
+      backtestConfig.isStateful,
       false, // isDryRun
       orgCursors.value[orgIndex], // Use stored cursor
     )

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -37,9 +37,20 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '1.4.1',
+    date: '2025-07-15',
+    description: 'Critical bug fix for backtest replay inconsistencies',
+    changes: {
+      fixed: [
+        'Inverted stateful processing logic - Fixed boolean inversion that caused backtests to run with opposite stateful setting than selected, resulting in different results compared to LimaCharlie native replay',
+      ],
+    },
+  },
+  {
     version: '1.4.0',
     date: '2025-07-12',
-    description: 'All changes in this release pertain exclusively to Unit Test sample event templates',
+    description:
+      'All changes in this release pertain exclusively to Unit Test sample event templates',
     changes: {
       added: [
         'Four New Event Types - EXISTING_PROCESS, SERVICE_CHANGE, SENSITIVE_PROCESS_ACCESS, NEW_REMOTE_THREAD templates for comprehensive detection rule testing',


### PR DESCRIPTION
## Release v1.4.1

### Summary
This release fixes a critical bug where the stateful processing setting in backtests was inverted, causing DetectionForge to produce different results than LimaCharlie's native replay feature.

### Changes
- **Fixed**: Inverted stateful processing logic - Fixed boolean inversion that caused backtests to run with opposite stateful setting than selected

### Technical Details
The `isStateful` parameter was being inverted (`\!backtestConfig.isStateful`) when passed to the API in three locations:
1. Parallel backtest execution
2. Sequential backtest execution  
3. Load more results functionality

This caused:
- Checkbox unchecked (false) → API received true (stateful enabled)
- Checkbox checked (true) → API received false (stateful disabled)

### Testing
To verify the fix:
1. Run a backtest with "Enable stateful processing" unchecked
2. Compare results with LimaCharlie's native replay
3. Results should now match when using the same time period and rule

### Release Checklist
- [x] Code changes implemented and tested
- [x] Changelog updated in `src/utils/version.ts`
- [x] Version bumped to 1.4.1
- [x] CI/CD validation passed
- [ ] Ready for merge

cc @ecapuano